### PR TITLE
Add onboarding flow for starting new conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.idea
+.vscode
+.DS_Store
+dist
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # graphchat
-Chatbot interface with tree like GUI
+GraphChat is a prototype interface for exploring branching conversations with large language models. Each exchange is
+visualised as a node in a tree so you can fork the discussion from any earlier point and compare outcomes side-by-side.
+
+## Technology stack
+
+- **Frontend:** React 18 with TypeScript, Vite, Tailwind CSS for utility-first styling, and React Flow (`@xyflow/react`)
+  for the interactive conversation tree.
+- **State management & data fetching:** React Query (`@tanstack/react-query`) – currently used for future backend
+  integration.
+- **Utilities:** `clsx` for conditional class names and `nanoid` for generating node IDs.
+
+## Getting started
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+### Running on Windows
+
+1. Install a recent [Node.js LTS build](https://nodejs.org/) for Windows. The installer includes `npm`.
+2. Open **PowerShell** (or **Command Prompt**) and navigate to the project directory, for example:
+   ```powershell
+   cd path\to\graphchat\client
+   ```
+3. Restore dependencies and start the development server:
+   ```powershell
+   npm install
+   npm run dev
+   ```
+4. Visit the printed local URL (typically `http://localhost:5173`) in your browser. Vite automatically reloads when you
+   save changes.
+
+The development server listens on port `5173` by default. Use a modern desktop or mobile browser to pan, zoom, and branch
+the conversation tree. If you are working in an offline or firewalled environment, installing dependencies from npm may
+require additional configuration.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GraphChat</title>
+  </head>
+  <body class="bg-background text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "graphchat-client",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.3",
+    "@xyflow/react": "^12.4.0",
+    "clsx": "^2.1.0",
+    "nanoid": "^5.0.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.6",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import BranchComposer from './components/BranchComposer';
+import ConversationTree from './components/ConversationTree';
+import NodeContextPanel from './components/NodeContextPanel';
+import StartConversation from './components/StartConversation';
+import { useConversationTree } from './hooks/useConversationTree';
+import type { ConversationNode } from './lib/types';
+
+const buildAncestorPath = (nodes: ConversationNode[], nodeId: string | null): ConversationNode[] => {
+  if (!nodeId) return [];
+  const byId = new Map(nodes.map((node) => [node.id, node] as const));
+  const path: ConversationNode[] = [];
+  let current = byId.get(nodeId) ?? null;
+  while (current) {
+    path.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) ?? null : null;
+  }
+  return path;
+};
+
+const App = () => {
+  const { nodes, selectedNodeId, setSelectedNodeId, createNode, resetConversation } = useConversationTree();
+
+  const selectedPath = useMemo(() => buildAncestorPath(nodes, selectedNodeId), [nodes, selectedNodeId]);
+
+  const handleStartConversation = async (message: string) => {
+    const rootNode = createNode({
+      parentId: null,
+      role: 'user',
+      content: message
+    });
+
+    const assistantNode = createNode({
+      parentId: rootNode.id,
+      role: 'assistant',
+      content: 'Assistant reply placeholder. Integrate with backend to fetch a real response.'
+    });
+
+    setSelectedNodeId(assistantNode.id);
+  };
+
+  const handleBranchSubmit = async (message: string) => {
+    if (!selectedNodeId) return;
+    const userNode = createNode({
+      parentId: selectedNodeId,
+      role: 'user',
+      content: message
+    });
+
+    const assistantNode = createNode({
+      parentId: userNode.id,
+      role: 'assistant',
+      content: 'Assistant reply placeholder. Integrate with backend to fetch a real response.'
+    });
+
+    setSelectedNodeId(assistantNode.id);
+  };
+
+  const hasConversation = nodes.length > 0;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="border-b border-slate-800 bg-slate-950/80 px-6 py-4 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-white">GraphChat</h1>
+            <p className="text-sm text-slate-400">
+              Branching conversations visualised as an interactive tree. Optimised for desktop and mobile.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={resetConversation}
+            className="inline-flex items-center justify-center rounded-xl border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-sky-200"
+          >
+            New conversation
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-6 md:px-6">
+        {!hasConversation && (
+          <div className="flex flex-1 items-center justify-center py-12">
+            <StartConversation onStart={handleStartConversation} />
+          </div>
+        )}
+
+        {hasConversation && (
+          <section className="grid flex-1 grid-cols-1 gap-6 xl:grid-cols-[2fr_1fr]">
+            <div className="flex min-h-[420px] flex-col gap-4">
+              <div className="relative flex-1 overflow-hidden">
+                <ConversationTree
+                  nodes={nodes}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={setSelectedNodeId}
+                />
+              </div>
+              <BranchComposer disabled={!selectedNodeId} onSubmit={handleBranchSubmit} />
+            </div>
+            <div className="flex min-h-[320px] flex-col">
+              <NodeContextPanel path={selectedPath} />
+            </div>
+          </section>
+        )}
+        <section className="grid grid-cols-1 gap-4 rounded-2xl border border-slate-800 bg-slate-900/50 p-4 text-sm text-slate-300 md:grid-cols-2">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Why a tree?</h2>
+            <p className="mt-2 leading-relaxed">
+              Linear transcripts make it hard to explore alternatives. GraphChat lets you branch from any message so you can
+              compare ideas side-by-side while keeping shared context intact.
+            </p>
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Mobile-friendly design</h2>
+            <p className="mt-2 leading-relaxed">
+              Pan, pinch, and zoom through the conversation tree on touch devices. Controls and layouts adapt down to small
+              screens so you can stay productive on the go.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/client/src/components/BranchComposer.tsx
+++ b/client/src/components/BranchComposer.tsx
@@ -1,0 +1,58 @@
+import { FormEvent, useState } from 'react';
+
+interface BranchComposerProps {
+  disabled?: boolean;
+  onSubmit: (value: string) => Promise<void> | void;
+}
+
+const BranchComposer = ({ disabled = false, onSubmit }: BranchComposerProps) => {
+  const [value, setValue] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!value.trim() || disabled) {
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      await onSubmit(value.trim());
+      setValue('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 rounded-2xl border border-slate-700 bg-slate-900/60 p-4">
+      <div>
+        <label htmlFor="branch-message" className="text-sm font-medium text-slate-200">
+          Continue or branch from the selected message
+        </label>
+        <p className="text-xs text-slate-400">
+          {disabled
+            ? 'Select a message bubble in the tree to decide where your new branch should begin.'
+            : 'Your follow-up will become a new branch and request a fresh assistant reply.'}
+        </p>
+      </div>
+      <textarea
+        id="branch-message"
+        name="branch-message"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="Type your message..."
+        rows={4}
+        className="w-full resize-y rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400"
+      />
+      <button
+        type="submit"
+        disabled={disabled || isSubmitting || !value.trim()}
+        className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+      >
+        {isSubmitting ? 'Adding branch…' : 'Add branch'}
+      </button>
+    </form>
+  );
+};
+
+export default BranchComposer;

--- a/client/src/components/ConversationTree.tsx
+++ b/client/src/components/ConversationTree.tsx
@@ -1,0 +1,148 @@
+import { memo, useMemo, useCallback } from 'react';
+import { ReactFlow, Background, Controls, MiniMap, type Edge, type Node, type NodeMouseHandler } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import type { ConversationNode } from '../lib/types';
+import { clsx } from 'clsx';
+
+interface ConversationTreeProps {
+  nodes: ConversationNode[];
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string) => void;
+}
+
+const nodeHeight = 84;
+const nodeWidth = 240;
+const verticalGap = 96;
+const horizontalGap = 200;
+
+const roleStyles: Record<string, string> = {
+  user: 'bg-sky-500/20 border-sky-400 text-sky-100',
+  assistant: 'bg-slate-700 border-slate-500 text-slate-100'
+};
+
+const formatTimestamp = (iso: string) => new Date(iso).toLocaleTimeString([], {
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+const ConversationTree = memo(({ nodes, selectedNodeId, onSelectNode }: ConversationTreeProps) => {
+  const nodeLookup = useMemo(() => new Map(nodes.map((node) => [node.id, node] as const)), [nodes]);
+
+  const { flowNodes, flowEdges } = useMemo(() => {
+    const roots = nodes.filter((node) => node.parentId === null);
+    const byParent = new Map<string | null, ConversationNode[]>();
+    for (const node of nodes) {
+      const bucket = byParent.get(node.parentId) ?? [];
+      bucket.push(node);
+      byParent.set(node.parentId, bucket);
+    }
+    for (const bucket of byParent.values()) {
+      bucket.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    }
+
+    type FlowNodeData = { node: ConversationNode };
+
+    const flowNodes: Node<FlowNodeData>[] = [];
+    const flowEdges: Edge[] = [];
+
+    const assignPositions = (
+      node: ConversationNode,
+      depth: number,
+      index: number,
+      yOffset: number
+    ) => {
+      const y = yOffset + index * (nodeHeight + verticalGap);
+      const x = depth * (nodeWidth + horizontalGap);
+      flowNodes.push({
+        id: node.id,
+        type: 'default',
+        position: { x, y },
+        data: { node },
+        style: {
+          width: nodeWidth,
+          height: nodeHeight
+        }
+      });
+
+      const children = byParent.get(node.id) ?? [];
+      children.forEach((child, childIndex) => {
+        flowEdges.push({
+          id: `${node.id}-${child.id}`,
+          source: node.id,
+          target: child.id,
+          type: 'smoothstep',
+          animated: child.role === 'assistant'
+        });
+        assignPositions(child, depth + 1, childIndex, y);
+      });
+    };
+
+    roots.forEach((root, rootIndex) => assignPositions(root, 0, rootIndex, rootIndex * (nodeHeight + verticalGap)));
+
+    return { flowNodes, flowEdges };
+  }, [nodes]);
+
+  const handleNodeClick = useCallback<NodeMouseHandler>(
+    (_, element) => {
+      if (element?.id) {
+        onSelectNode(element.id);
+      }
+    },
+    [onSelectNode]
+  );
+
+  return (
+    <div className="relative h-full w-full rounded-2xl border border-slate-700 bg-slate-900/60">
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        fitView
+        minZoom={0.25}
+        maxZoom={1.4}
+        attributionPosition="top-right"
+        proOptions={{ hideAttribution: true }}
+        className="rounded-2xl"
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable
+        onNodeClick={handleNodeClick}
+      >
+        <Background color="#1e293b" gap={32} size={1} />
+        <MiniMap maskColor="rgba(15,23,42,0.7)" pannable zoomable />
+        <Controls showInteractive={false} position="bottom-right" />
+      </ReactFlow>
+      <div className="pointer-events-none absolute inset-0">
+        {flowNodes.map((node) => {
+          const original = nodeLookup.get(node.id);
+          if (!original) return null;
+          return (
+          <button
+            key={node.id}
+            type="button"
+            onClick={() => onSelectNode(node.id)}
+            className={clsx(
+              'pointer-events-auto absolute flex h-[84px] w-[240px] flex-col rounded-2xl border px-4 py-3 text-left shadow-lg transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400',
+              roleStyles[original.role],
+              selectedNodeId === node.id && 'ring-2 ring-offset-2 ring-offset-slate-900 ring-sky-400'
+            )}
+            style={{
+              transform: `translate(${node.position.x}px, ${node.position.y}px)`
+            }}
+          >
+            <span className="text-xs uppercase tracking-wide text-slate-300">
+              {original.role === 'user' ? 'You' : 'Assistant'} · {formatTimestamp(original.createdAt)}
+            </span>
+            <span className="clamp-3 mt-2 text-sm text-slate-50">
+              {original.content}
+            </span>
+          </button>
+        );
+        })}
+      </div>
+    </div>
+  );
+});
+
+ConversationTree.displayName = 'ConversationTree';
+
+export default ConversationTree;

--- a/client/src/components/NodeContextPanel.tsx
+++ b/client/src/components/NodeContextPanel.tsx
@@ -1,0 +1,40 @@
+import type { ConversationNode } from '../lib/types';
+
+interface NodeContextPanelProps {
+  path: ConversationNode[];
+}
+
+const roleLabel: Record<string, string> = {
+  user: 'You',
+  assistant: 'Assistant'
+};
+
+const NodeContextPanel = ({ path }: NodeContextPanelProps) => {
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-900/60">
+      <div className="border-b border-slate-700 px-4 py-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Context</h2>
+        <p className="mt-1 text-xs text-slate-400">
+          The selected message inherits everything in this path when requesting a new assistant reply.
+        </p>
+      </div>
+      <div className="scrollbar-thin flex-1 space-y-3 overflow-y-auto px-4 py-4">
+        {path.map((node) => (
+          <div key={node.id} className="rounded-xl border border-slate-700/60 bg-slate-800/60 px-3 py-2 text-sm text-slate-100">
+            <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+              {roleLabel[node.role]}
+            </span>
+            <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-slate-100">{node.content}</p>
+          </div>
+        ))}
+        {path.length === 0 && (
+          <p className="text-sm text-slate-400">
+            Select a node to inspect the conversation context.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NodeContextPanel;

--- a/client/src/components/StartConversation.tsx
+++ b/client/src/components/StartConversation.tsx
@@ -1,0 +1,56 @@
+import { FormEvent, useState } from 'react';
+
+interface StartConversationProps {
+  onStart: (message: string) => Promise<void> | void;
+}
+
+const StartConversation = ({ onStart }: StartConversationProps) => {
+  const [value, setValue] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      await onStart(trimmed);
+      setValue('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full max-w-xl flex-col gap-4 rounded-2xl border border-slate-700 bg-slate-900/60 p-6 text-left"
+    >
+      <div>
+        <h2 className="text-lg font-semibold text-white">Start a new conversation</h2>
+        <p className="mt-1 text-sm text-slate-400">
+          Ask the assistant anything to create the root of your conversation tree.
+        </p>
+      </div>
+      <textarea
+        name="initial-message"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        rows={5}
+        placeholder="Describe what you need help with..."
+        className="w-full resize-y rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400"
+      />
+      <button
+        type="submit"
+        disabled={isSubmitting || !value.trim()}
+        className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+      >
+        {isSubmitting ? 'Starting…' : 'Start conversation'}
+      </button>
+    </form>
+  );
+};
+
+export default StartConversation;

--- a/client/src/hooks/useConversationTree.ts
+++ b/client/src/hooks/useConversationTree.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+import { nanoid } from 'nanoid';
+import type { ConversationNode, MessageRole } from '../lib/types';
+
+interface CreateNodeOptions {
+  parentId: string | null;
+  role: MessageRole;
+  content: string;
+}
+
+export const useConversationTree = () => {
+  const [nodes, setNodes] = useState<ConversationNode[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [conversationId, setConversationId] = useState<string>(() => nanoid());
+
+  const createNode = useCallback(({ parentId, role, content }: CreateNodeOptions) => {
+    let newNode: ConversationNode | null = null;
+    setNodes((prev) => {
+      newNode = {
+        id: nanoid(),
+        parentId,
+        role,
+        content,
+        createdAt: new Date().toISOString(),
+        conversationId
+      };
+      return [...prev, newNode];
+    });
+    return newNode!;
+  }, [conversationId]);
+
+  const resetConversation = useCallback(() => {
+    setConversationId(nanoid());
+    setNodes([]);
+    setSelectedNodeId(null);
+  }, []);
+
+  return {
+    nodes,
+    selectedNodeId,
+    setSelectedNodeId,
+    createNode,
+    resetConversation
+  };
+};

--- a/client/src/lib/mockData.ts
+++ b/client/src/lib/mockData.ts
@@ -1,0 +1,43 @@
+import type { Conversation, ConversationNode } from './types';
+
+export const mockConversation: Conversation = {
+  id: 'conv-1',
+  title: 'Prototype Conversation',
+  rootId: 'node-1',
+  createdAt: new Date().toISOString()
+};
+
+export const mockNodes: ConversationNode[] = [
+  {
+    id: 'node-1',
+    parentId: null,
+    role: 'user',
+    content: 'How can we visualise branching AI conversations?',
+    createdAt: new Date().toISOString(),
+    conversationId: 'conv-1'
+  },
+  {
+    id: 'node-2',
+    parentId: 'node-1',
+    role: 'assistant',
+    content: 'We could render them as a tree where each branch represents a fork.',
+    createdAt: new Date().toISOString(),
+    conversationId: 'conv-1'
+  },
+  {
+    id: 'node-3',
+    parentId: 'node-2',
+    role: 'user',
+    content: 'Show me how a branching follow-up might work.',
+    createdAt: new Date().toISOString(),
+    conversationId: 'conv-1'
+  },
+  {
+    id: 'node-4',
+    parentId: 'node-2',
+    role: 'user',
+    content: 'What about mobile responsiveness?',
+    createdAt: new Date().toISOString(),
+    conversationId: 'conv-1'
+  }
+];

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -1,0 +1,17 @@
+export type MessageRole = 'user' | 'assistant';
+
+export interface ConversationNode {
+  id: string;
+  parentId: string | null;
+  role: MessageRole;
+  content: string;
+  createdAt: string;
+  conversationId: string;
+}
+
+export interface Conversation {
+  id: string;
+  title: string;
+  rootId: string | null;
+  createdAt: string;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './styles/index.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: theme('colors.background');
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.4);
+  border-radius: 9999px;
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0f172a',
+        surface: '#1e293b',
+        accent: '#38bdf8'
+      }
+    }
+  },
+  plugins: []
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- add a zero-state onboarding form so users can start a new tree-backed conversation
- reset the conversation state from the header action and set selections on new replies for smooth branching
- adjust the React Flow integration and composer messaging to satisfy TypeScript and guide users when no node is selected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab3ca1c28832399e3e950120b897b