### PR TITLE
Implement Branch tree chat frontend

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: ["eslint:recommended", "plugin:react/recommended", "plugin:react-hooks/recommended", "prettier"],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: "latest",
+    sourceType: "module"
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
+  },
+  plugins: ["react", "react-hooks"],
+  rules: {
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# graphchat
+# Branch · Tree Chat Frontend
+
+A single-page React + TypeScript application that implements the Branch conversation canvas described in the Tree-Chat Frontend Spec. The app lets you create and manage multiple chats, each rendered as a forest of draggable, resizable nodes on an infinite canvas with pan/zoom, linking, import/export, and undo/redo.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Visit http://localhost:5173 to interact with the app.
+
+## Scripts
+
+- `pnpm dev` – start Vite dev server.
+- `pnpm build` – build production bundle.
+- `pnpm preview` – preview production build.
+- `pnpm lint` – run ESLint with the provided config.
+- `pnpm test` – execute unit tests with Vitest (placeholder; add tests in `src/__tests__`).
+
+## Key Features
+
+- Collapsible sidebar listing chats with search, creation, and deletion controls.
+- Infinite canvas with dotted grid background, smooth pan/zoom, and viewport controls.
+- Node cards for user, assistant, and note roles with inline editing, resizing, and status badges.
+- Drag-and-drop linking and branching, active-path highlighting, and tree invariant enforcement.
+- LocalStorage persistence with schema versioning, import/export helpers, and undo/redo history.
+
+Refer to the source in `src/` for additional details on the state model and UI components.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Branch · Tree Chat</title>
+  </head>
+  <body class="bg-canvas-dark text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "branch-tree-chat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --max-warnings 0",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.3",
+    "@tanstack/react-virtual": "^3.1.1",
+    "d3-zoom": "^3.0.0",
+    "date-fns": "^3.6.0",
+    "immer": "^10.0.3",
+    "nanoid": "^5.0.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hotkeys-hook": "^4.4.0",
+    "react-router-dom": "^6.21.3",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/d3-zoom": "^3.0.2",
+    "@types/node": "^20.11.5",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "jsdom": "^23.0.1",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8",
+    "vitest": "^1.1.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import { Routes, Route, useNavigate, useParams } from "react-router-dom";
+import { useActions, useAppState } from "./state/store";
+import Sidebar from "./features/sidebar/Sidebar";
+import CanvasView from "./features/canvas/CanvasView";
+import TopBar from "./components/TopBar";
+import { useKeyboardShortcuts } from "./features/keyboard/useKeyboardShortcuts";
+
+function ChatRoute() {
+  const { chatId } = useParams<{ chatId: string }>();
+  const state = useAppState();
+  const actions = useActions();
+
+  useEffect(() => {
+    if (!chatId) return;
+    if (!state.chats[chatId]) {
+      actions.setActiveChat(chatId);
+    } else if (state.activeChatId !== chatId) {
+      actions.setActiveChat(chatId);
+    }
+  }, [actions, chatId, state.activeChatId, state.chats]);
+
+  if (!chatId) {
+    return <div className="flex-1" />;
+  }
+
+  return <CanvasView chatId={chatId} />;
+}
+
+function AppRoutes() {
+  const navigate = useNavigate();
+  const actions = useActions();
+  const state = useAppState();
+
+  useEffect(() => {
+    if (!state.chatOrder.length) {
+      const id = actions.createChat();
+      navigate(`/chat/${id}`, { replace: true });
+      return;
+    }
+    if (!state.activeChatId) {
+      navigate(`/chat/${state.chatOrder[0]}`, { replace: true });
+    }
+  }, [actions, navigate, state.activeChatId, state.chatOrder]);
+
+  useKeyboardShortcuts();
+
+  return (
+    <div className="flex h-screen w-screen overflow-hidden bg-canvas-dark text-slate-100">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <TopBar />
+        <Routes>
+          <Route path="/chat/:chatId" element={<ChatRoute />} />
+          <Route path="*" element={<div className="flex-1" />} />
+        </Routes>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return <AppRoutes />;
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,48 @@
+import { ArrowDownTrayIcon, ArrowUpTrayIcon, SwatchIcon } from "@heroicons/react/24/outline";
+import { useAppState, useActions } from "../state/store";
+import { exportChats, importChats } from "../utils/persistence";
+
+export default function TopBar() {
+  const state = useAppState();
+  const actions = useActions();
+  const activeChat = state.activeChatId ? state.chats[state.activeChatId] : undefined;
+
+  return (
+    <header className="flex items-center justify-between border-b border-slate-800 bg-slate-950/80 px-4 py-2 backdrop-blur">
+      <div>
+        <h1 className="text-lg font-semibold text-slate-100">Branch</h1>
+        {activeChat ? (
+          <p className="text-xs text-slate-400">{activeChat.meta.title}</p>
+        ) : (
+          <p className="text-xs text-slate-400">Create a chat to begin</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2 text-sm">
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1 text-slate-200 hover:bg-slate-800"
+          onClick={() => importChats(actions.importData)}
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          Import
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1 text-slate-200 hover:bg-slate-800"
+          onClick={() => exportChats(state)}
+        >
+          <ArrowUpTrayIcon className="h-4 w-4" />
+          Export
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1 text-slate-200 hover:bg-slate-800"
+          onClick={() => actions.toggleGridSnap()}
+        >
+          <SwatchIcon className="h-4 w-4" />
+          {state.ui.gridSnap ? "Snap" : "Free"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/features/canvas/CanvasView.tsx
+++ b/src/features/canvas/CanvasView.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useMemo, useState } from "react";
+import { PlusIcon, MinusIcon, ArrowsPointingOutIcon } from "@heroicons/react/24/outline";
+import { useActions, useAppState } from "../../state/store";
+import NodeCard from "./NodeCard";
+import EdgesLayer from "./EdgesLayer";
+import { usePanZoom } from "./usePanZoom";
+import type { ChatNode } from "../../state/types";
+import { getAncestors } from "../../utils/tree";
+
+interface CanvasViewProps {
+  chatId: string;
+}
+
+export default function CanvasView({ chatId }: CanvasViewProps) {
+  const state = useAppState();
+  const actions = useActions();
+  const chat = state.chats[chatId];
+  const viewport = chat.meta.viewport;
+  const [linkingFrom, setLinkingFrom] = useState<string | undefined>();
+  const [linkingPoint, setLinkingPoint] = useState<{ x: number; y: number } | undefined>();
+
+  const { handleWheel, handlePointerDown, handlePointerMove, handlePointerUp } = usePanZoom({
+    viewport,
+    onChange: (next) => actions.setViewport(chatId, next)
+  });
+
+  const nodes = chat.nodes;
+  const selection = state.selection;
+
+  const screenToWorld = useCallback(
+    (x: number, y: number) => ({
+      x: (x - viewport.x) / viewport.zoom,
+      y: (y - viewport.y) / viewport.zoom
+    }),
+    [viewport.x, viewport.y, viewport.zoom]
+  );
+
+  const handleCanvasPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button === 0) {
+        actions.clearSelection();
+      }
+      handlePointerDown(event.nativeEvent);
+    },
+    [actions, handlePointerDown]
+  );
+
+  const handleCanvasPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      handlePointerMove(event.nativeEvent);
+      if (linkingFrom) {
+        const point = screenToWorld(event.clientX, event.clientY);
+        setLinkingPoint(point);
+      }
+    },
+    [handlePointerMove, linkingFrom, screenToWorld]
+  );
+
+  const handleCanvasPointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      handlePointerUp(event.nativeEvent);
+      if (linkingFrom) {
+        const world = screenToWorld(event.clientX, event.clientY);
+        const newId = actions.createNode({
+          chatId,
+          parentId: linkingFrom,
+          x: world.x,
+          y: world.y,
+          role: "assistant"
+        });
+        actions.selectNodes([newId]);
+        setLinkingFrom(undefined);
+        setLinkingPoint(undefined);
+      }
+    },
+    [actions, chatId, handlePointerUp, linkingFrom, screenToWorld]
+  );
+
+  const handleStartLink = useCallback(
+    (nodeId: string) => {
+      setLinkingPoint(undefined);
+      setLinkingFrom((current) => (current === nodeId ? undefined : nodeId));
+    },
+    []
+  );
+
+  const handleCompleteLink = useCallback(
+    (sourceId: string, targetId: string) => {
+      if (sourceId === targetId) return;
+      actions.reparentNode(targetId, sourceId);
+      setLinkingFrom(undefined);
+      setLinkingPoint(undefined);
+    },
+    [actions]
+  );
+
+  const zoomIn = () => {
+    actions.setViewport(chatId, { ...viewport, zoom: Math.min(viewport.zoom * 1.1, 2) });
+  };
+  const zoomOut = () => {
+    actions.setViewport(chatId, { ...viewport, zoom: Math.max(viewport.zoom * 0.9, 0.25) });
+  };
+  const fitView = () => {
+    const nodeList = Object.values(nodes);
+    if (!nodeList.length) return;
+    const minX = Math.min(...nodeList.map((n) => n.x));
+    const minY = Math.min(...nodeList.map((n) => n.y));
+    const maxX = Math.max(...nodeList.map((n) => n.x + n.width));
+    const maxY = Math.max(...nodeList.map((n) => n.y + n.height));
+    const padding = 200;
+    const width = maxX - minX + padding;
+    const height = maxY - minY + padding;
+    const scaleX = window.innerWidth / width;
+    const scaleY = window.innerHeight / height;
+    const newZoom = Math.min(Math.max(Math.min(scaleX, scaleY), 0.25), 2);
+    actions.setViewport(chatId, {
+      zoom: newZoom,
+      x: -minX * newZoom + padding / 2,
+      y: -minY * newZoom + padding / 2
+    });
+  };
+
+  const sortedNodes = useMemo(() => Object.values(nodes) as ChatNode[], [nodes]);
+  const activeSelectionId = selection.nodeIds[0];
+  const activePath = useMemo(() => {
+    if (!activeSelectionId) return new Set<string>();
+    const path = getAncestors(nodes, activeSelectionId);
+    return new Set(path.map((node) => node.id));
+  }, [activeSelectionId, nodes]);
+
+  return (
+    <div className="relative flex-1 overflow-hidden" role="application">
+      <div
+        className="absolute inset-0"
+        onPointerDown={handleCanvasPointerDown}
+        onPointerMove={handleCanvasPointerMove}
+        onPointerUp={handleCanvasPointerUp}
+        onWheel={(event) => handleWheel(event.nativeEvent)}
+      >
+        <div className="canvas-grid absolute inset-0" />
+        <div
+          className="absolute inset-0"
+          style={{
+            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+            transformOrigin: "0 0"
+          }}
+        >
+          <EdgesLayer
+            nodes={nodes}
+            selectedEdge={selection.edge}
+            onSelectEdge={(parentId, childId) => actions.selectEdge(parentId, childId)}
+            activePath={activePath}
+        />
+        {sortedNodes.map((node) => (
+          <NodeCard
+            key={node.id}
+            node={node}
+            selected={selection.nodeIds.includes(node.id)}
+            scale={viewport.zoom}
+            linkingFrom={linkingFrom}
+            onStartLink={handleStartLink}
+            onCompleteLink={handleCompleteLink}
+            inActivePath={activePath.has(node.id)}
+          />
+        ))}
+          {linkingFrom && linkingPoint && nodes[linkingFrom] && (
+            <svg className="pointer-events-none absolute inset-0">
+              <line
+                x1={nodes[linkingFrom].x + nodes[linkingFrom].width / 2}
+                y1={nodes[linkingFrom].y + nodes[linkingFrom].height / 2}
+                x2={linkingPoint.x}
+                y2={linkingPoint.y}
+                stroke="#38bdf8"
+                strokeWidth={1.5}
+              />
+            </svg>
+          )}
+        </div>
+      </div>
+      <div className="pointer-events-auto absolute bottom-6 right-6 flex flex-col gap-2">
+        <button
+          type="button"
+          className="rounded-full bg-slate-900/90 p-3 text-slate-200 shadow-lg hover:bg-slate-800"
+          onClick={zoomIn}
+          aria-label="Zoom in"
+        >
+          <PlusIcon className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-slate-900/90 p-3 text-slate-200 shadow-lg hover:bg-slate-800"
+          onClick={zoomOut}
+          aria-label="Zoom out"
+        >
+          <MinusIcon className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-slate-900/90 p-3 text-slate-200 shadow-lg hover:bg-slate-800"
+          onClick={fitView}
+          aria-label="Fit to content"
+        >
+          <ArrowsPointingOutIcon className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/canvas/EdgesLayer.tsx
+++ b/src/features/canvas/EdgesLayer.tsx
@@ -1,0 +1,85 @@
+import { memo } from "react";
+import type { ChatNode } from "../../state/types";
+
+interface EdgeLayerProps {
+  nodes: Record<string, ChatNode>;
+  selectedEdge?: { parentId: string; childId: string };
+  onSelectEdge: (parentId: string, childId: string) => void;
+  activePath?: Set<string>;
+}
+
+function anchorPoint(parent: ChatNode, child: ChatNode) {
+  const parentCenter = { x: parent.x + parent.width / 2, y: parent.y + parent.height / 2 };
+  const childCenter = { x: child.x + child.width / 2, y: child.y + child.height / 2 };
+  const dx = childCenter.x - parentCenter.x;
+  const dy = childCenter.y - parentCenter.y;
+  const absDx = Math.abs(dx);
+  const absDy = Math.abs(dy);
+
+  if (absDx > absDy) {
+    const parentX = dx > 0 ? parent.x + parent.width : parent.x;
+    const childX = dx > 0 ? child.x : child.x + child.width;
+    return {
+      source: { x: parentX, y: parentCenter.y },
+      target: { x: childX, y: childCenter.y }
+    };
+  }
+
+  const parentY = dy > 0 ? parent.y + parent.height : parent.y;
+  const childY = dy > 0 ? child.y : child.y + child.height;
+  return {
+    source: { x: parentCenter.x, y: parentY },
+    target: { x: childCenter.x, y: childY }
+  };
+}
+
+function EdgesLayerComponent({ nodes, selectedEdge, onSelectEdge, activePath }: EdgeLayerProps) {
+  const edges = Object.values(nodes)
+    .filter((node) => node.parentId)
+    .map((node) => ({ parent: nodes[node.parentId!], child: node }));
+
+  return (
+    <svg className="absolute inset-0 h-full w-full" data-testid="edges-layer">
+      <defs>
+        <marker
+          id="arrowhead"
+          markerWidth="6"
+          markerHeight="6"
+          refX="6"
+          refY="3"
+          orient="auto"
+        >
+          <path d="M0,0 L0,6 L6,3 z" fill="rgba(148, 163, 184, 0.9)" />
+        </marker>
+      </defs>
+      {edges.map(({ parent, child }) => {
+        if (!parent) return null;
+        const { source, target } = anchorPoint(parent, child);
+        const isSelected =
+          selectedEdge &&
+          selectedEdge.parentId === parent.id &&
+          selectedEdge.childId === child.id;
+        const inActivePath = activePath?.has(parent.id) && activePath?.has(child.id);
+        return (
+          <g key={`${parent.id}-${child.id}`}>
+            <path
+              d={`M ${source.x} ${source.y} L ${target.x} ${target.y}`}
+              stroke={isSelected ? "#38bdf8" : inActivePath ? "#34d399" : "rgba(148, 163, 184, 0.6)"}
+              strokeWidth={isSelected || inActivePath ? 2.5 : 1.8}
+              fill="none"
+              markerEnd="url(#arrowhead)"
+              className="cursor-pointer"
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectEdge(parent.id, child.id);
+              }}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+const EdgesLayer = memo(EdgesLayerComponent);
+export default EdgesLayer;

--- a/src/features/canvas/NodeCard.tsx
+++ b/src/features/canvas/NodeCard.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import {
+  ArrowsPointingOutIcon,
+  EllipsisHorizontalIcon,
+  PlusSmallIcon
+} from "@heroicons/react/24/outline";
+import type { ChatNode } from "../../state/types";
+import { useActions, useAppState } from "../../state/store";
+import { snap } from "../../utils/math";
+import { pathMessages } from "../../utils/context";
+
+interface NodeCardProps {
+  node: ChatNode;
+  selected: boolean;
+  scale: number;
+  linkingFrom?: string;
+  onStartLink: (nodeId: string) => void;
+  onCompleteLink: (sourceId: string, targetId: string) => void;
+  inActivePath?: boolean;
+}
+
+export default function NodeCard({
+  node,
+  selected,
+  scale,
+  linkingFrom,
+  onStartLink,
+  onCompleteLink,
+  inActivePath
+}: NodeCardProps) {
+  const actions = useActions();
+  const state = useAppState();
+  const gridSnap = state.ui.gridSnap;
+  const [isDragging, setDragging] = useState(false);
+  const dragOffset = useRef({ x: 0, y: 0 });
+  const resizeStart = useRef({ width: node.width, height: node.height, x: 0, y: 0 });
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if ((event.target as HTMLElement).closest("textarea")) return;
+      event.preventDefault();
+      dragOffset.current = {
+        x: event.clientX - node.x * scale - state.chats[node.chatId].meta.viewport.x,
+        y: event.clientY - node.y * scale - state.chats[node.chatId].meta.viewport.y
+      };
+      setDragging(true);
+      (event.target as HTMLElement).setPointerCapture(event.pointerId);
+    },
+    [node.chatId, node.x, node.y, scale, state.chats]
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isDragging) return;
+      event.preventDefault();
+      const chat = state.chats[node.chatId];
+      const vx = chat.meta.viewport.x;
+      const vy = chat.meta.viewport.y;
+      const x = (event.clientX - dragOffset.current.x - vx) / scale;
+      const y = (event.clientY - dragOffset.current.y - vy) / scale;
+      actions.setNodePosition(
+        node.id,
+        gridSnap ? snap(x, 8) : x,
+        gridSnap ? snap(y, 8) : y
+      );
+    },
+    [actions, gridSnap, isDragging, node.chatId, node.id, scale, state.chats]
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isDragging) return;
+      event.preventDefault();
+      setDragging(false);
+      (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+    },
+    [isDragging]
+  );
+
+  const handleResizeDown = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    resizeStart.current = {
+      width: node.width,
+      height: node.height,
+      x: event.clientX,
+      y: event.clientY
+    };
+    (event.target as HTMLElement).setPointerCapture(event.pointerId);
+  }, [node.height, node.width]);
+
+  const handleResizeMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!(event.target as HTMLElement).hasPointerCapture(event.pointerId)) return;
+      event.preventDefault();
+      const dx = (event.clientX - resizeStart.current.x) / scale;
+      const dy = (event.clientY - resizeStart.current.y) / scale;
+      actions.resizeNode(node.id, resizeStart.current.width + dx, resizeStart.current.height + dy);
+    },
+    [actions, node.id, scale]
+  );
+
+  const handleResizeUp = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+  }, []);
+
+  const handleAskAi = useCallback(() => {
+    const chat = state.chats[node.chatId];
+    if (!chat) return;
+    const messages = pathMessages(chat, node.id);
+    const prompt = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+    const childId = actions.createNode({
+      chatId: node.chatId,
+      parentId: node.id,
+      x: node.x,
+      y: node.y + node.height + 180,
+      role: "assistant",
+      autoFocus: false
+    });
+    actions.setNodeStatus(childId, "sending");
+    const mock = `Here is a continuation based on the context:\n${prompt}`;
+    let index = 0;
+    const interval = window.setInterval(() => {
+      index += 8;
+      actions.updateNodeText(childId, mock.slice(0, index));
+      if (index >= mock.length) {
+        window.clearInterval(interval);
+        actions.setNodeStatus(childId, "done");
+      }
+    }, 50);
+  }, [actions, node, state.chats]);
+
+  const roleStyles: Record<ChatNode["role"], string> = {
+    user: "bg-slate-800/80 border border-slate-600",
+    assistant: "bg-slate-700/80 border border-slate-500",
+    note: "bg-slate-600/80 border border-slate-400"
+  };
+
+  return (
+    <div
+      role="group"
+      className={`absolute flex flex-col rounded-xl p-0 text-slate-100 shadow-lg transition-all ${roleStyles[node.role]} ${
+        selected
+          ? "ring-2 ring-sky-400"
+          : inActivePath
+            ? "ring-2 ring-emerald-500/50"
+            : "ring-1 ring-slate-800/60"
+      }`}
+      style={{
+        left: node.x,
+        top: node.y,
+        width: node.width,
+        height: node.height,
+        transformOrigin: "top left"
+      }}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+        if (event.button === 0) {
+          actions.selectNodes([node.id]);
+        }
+      }}
+      onPointerUp={(event) => {
+        event.stopPropagation();
+        if (linkingFrom && linkingFrom !== node.id) {
+          event.stopPropagation();
+          onCompleteLink(linkingFrom, node.id);
+        }
+      }}
+    >
+      <div
+        className="flex cursor-move select-none items-center justify-between rounded-t-xl bg-slate-950/60 px-3 py-2 text-xs uppercase tracking-wide"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        <span className="rounded-full border border-slate-600 px-2 py-0.5 text-[10px] font-semibold">
+          {node.role}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="rounded bg-slate-800/80 p-1 hover:bg-sky-500/30"
+            aria-label="Add child"
+            onClick={(event) => {
+              event.stopPropagation();
+              actions.createNode({
+                chatId: node.chatId,
+                parentId: node.id,
+                x: node.x + node.width + 40,
+                y: node.y + node.height + 40,
+                role: node.role === "user" ? "assistant" : "user"
+              });
+            }}
+          >
+            <PlusSmallIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className="rounded bg-slate-800/80 p-1 hover:bg-slate-700"
+            aria-label="Start link"
+            onClick={(event) => {
+              event.stopPropagation();
+              onStartLink(node.id);
+            }}
+          >
+            <ArrowsPointingOutIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className="rounded bg-slate-800/80 p-1 hover:bg-slate-700"
+            aria-haspopup="menu"
+          >
+            <EllipsisHorizontalIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      <textarea
+        aria-multiline
+        className="flex-1 resize-none bg-transparent px-4 py-3 text-sm leading-relaxed text-slate-100 focus:outline-none"
+        value={node.text}
+        placeholder={node.role === "assistant" ? "Assistant response" : "Enter message"}
+        onChange={(event) => actions.updateNodeText(node.id, event.target.value)}
+        onFocus={() => actions.setEditingNode(node.id)}
+        onBlur={() => actions.setEditingNode(undefined)}
+      />
+      <div className="flex items-center justify-between border-t border-slate-700/60 px-3 py-1 text-[10px] uppercase tracking-wide text-slate-400">
+        <span>{node.status}</span>
+        <span>{node.text.length} chars</span>
+      </div>
+      {node.role !== "assistant" && (
+        <button
+          type="button"
+          className="mx-3 mb-2 rounded-md border border-slate-600 bg-slate-800/80 px-3 py-1 text-xs uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+          onClick={handleAskAi}
+        >
+          Ask AI
+        </button>
+      )}
+      <button
+        type="button"
+        className="absolute bottom-1 right-1 h-5 w-5 cursor-se-resize rounded bg-slate-900/70 p-1 text-slate-300"
+        aria-label="Resize"
+        onPointerDown={handleResizeDown}
+        onPointerMove={handleResizeMove}
+        onPointerUp={handleResizeUp}
+      >
+        <ArrowsPointingOutIcon className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/features/canvas/usePanZoom.ts
+++ b/src/features/canvas/usePanZoom.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { ViewportState } from "../../state/types";
+
+interface PanZoomOptions {
+  viewport: ViewportState;
+  onChange: (next: ViewportState) => void;
+}
+
+export function usePanZoom({ viewport, onChange }: PanZoomOptions) {
+  const stateRef = useRef(viewport);
+  const isPanning = useRef(false);
+  const last = useRef({ x: 0, y: 0 });
+  const spacePressed = useRef(false);
+
+  useEffect(() => {
+    stateRef.current = viewport;
+  }, [viewport]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code === "Space") {
+        spacePressed.current = true;
+      }
+    };
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.code === "Space") {
+        spacePressed.current = false;
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (event.ctrlKey) {
+        event.preventDefault();
+        const { offsetX, offsetY, deltaY } = event;
+        const zoomFactor = Math.exp(-deltaY / 500);
+        const current = stateRef.current;
+        const newZoom = Math.min(Math.max(current.zoom * zoomFactor, 0.25), 2);
+        const scale = newZoom / current.zoom;
+        const newX = offsetX - (offsetX - current.x) * scale;
+        const newY = offsetY - (offsetY - current.y) * scale;
+        onChange({ x: newX, y: newY, zoom: newZoom });
+      }
+    },
+    [onChange]
+  );
+
+  const handlePointerDown = useCallback((event: PointerEvent) => {
+    const allowPan =
+      event.button === 1 ||
+      (event.button === 0 && (event.shiftKey || spacePressed.current)) ||
+      event.altKey;
+    if (!allowPan) {
+      return;
+    }
+    event.preventDefault();
+    isPanning.current = true;
+    last.current = { x: event.clientX, y: event.clientY };
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!isPanning.current) return;
+      event.preventDefault();
+      const dx = event.clientX - last.current.x;
+      const dy = event.clientY - last.current.y;
+      last.current = { x: event.clientX, y: event.clientY };
+      const current = stateRef.current;
+      onChange({ x: current.x + dx, y: current.y + dy, zoom: current.zoom });
+    },
+    [onChange]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    isPanning.current = false;
+  }, []);
+
+  return { handleWheel, handlePointerDown, handlePointerMove, handlePointerUp };
+}

--- a/src/features/keyboard/useKeyboardShortcuts.ts
+++ b/src/features/keyboard/useKeyboardShortcuts.ts
@@ -1,0 +1,143 @@
+import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { useActions, useAppState } from "../../state/store";
+
+export function useKeyboardShortcuts() {
+  const actions = useActions();
+  const state = useAppState();
+  const selection = state.selection;
+  const activeChat = state.activeChatId ? state.chats[state.activeChatId] : undefined;
+
+  useHotkeys(
+    ["ctrl+z", "meta+z"],
+    (event) => {
+      event.preventDefault();
+      actions.undo();
+    },
+    [actions]
+  );
+
+  useHotkeys(
+    ["ctrl+shift+z", "meta+shift+z", "ctrl+y", "meta+y"],
+    (event) => {
+      event.preventDefault();
+      actions.redo();
+    },
+    [actions]
+  );
+
+  useHotkeys(
+    "delete",
+    () => {
+      if (selection.edge) {
+        actions.deleteEdge(selection.edge.parentId, selection.edge.childId);
+      } else if (selection.nodeIds.length) {
+        actions.deleteNode(selection.nodeIds[0], "subtree");
+      }
+    },
+    [actions, selection]
+  );
+
+  useHotkeys(
+    ["ctrl+d", "meta+d"],
+    (event) => {
+      if (!activeChat || !selection.nodeIds.length) return;
+      event.preventDefault();
+      const created: string[] = [];
+      selection.nodeIds.forEach((id) => {
+        const node = activeChat.nodes[id];
+        if (!node) return;
+        const newId = actions.createNode({
+          chatId: activeChat.meta.id,
+          parentId: node.parentId,
+          role: node.role,
+          x: node.x + 40,
+          y: node.y + 40,
+          autoFocus: false
+        });
+        actions.resizeNode(newId, node.width, node.height);
+        actions.updateNodeText(newId, node.text);
+        actions.setNodeStatus(newId, node.status);
+        created.push(newId);
+      });
+      if (created.length) {
+        actions.selectNodes(created);
+      }
+    },
+    [actions, activeChat, selection.nodeIds]
+  );
+
+  useHotkeys(
+    "esc",
+    () => {
+      actions.clearSelection();
+      actions.setEditingNode(undefined);
+    },
+    [actions]
+  );
+
+  useHotkeys(
+    ["up", "down", "left", "right"],
+    (event, handler) => {
+      if (!selection.nodeIds.length || !activeChat) return;
+      const delta = event.shiftKey ? 10 : 1;
+      let dx = 0;
+      let dy = 0;
+      switch (handler.keys?.join("+")) {
+        case "up":
+          dy = -delta;
+          break;
+        case "down":
+          dy = delta;
+          break;
+        case "left":
+          dx = -delta;
+          break;
+        case "right":
+          dx = delta;
+          break;
+        default:
+          break;
+      }
+      if (dx !== 0 || dy !== 0) {
+        event.preventDefault();
+        actions.moveNodes(selection.nodeIds, dx, dy);
+      }
+    },
+    [actions, activeChat, selection.nodeIds]
+  );
+
+  useHotkeys(
+    "n",
+    (event) => {
+      if (event.target instanceof HTMLElement && event.target.isContentEditable) return;
+      event.preventDefault();
+      const chatId = state.activeChatId;
+      if (!chatId) return;
+      const viewport = state.chats[chatId].meta.viewport;
+      actions.createNode({
+        chatId,
+        x: viewport.x,
+        y: viewport.y,
+        role: "user"
+      });
+    },
+    [actions, state]
+  );
+
+  useEffect(() => {
+    const handleSave = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        const toast = document.createElement("div");
+        toast.textContent = "State saved";
+        toast.className =
+          "fixed bottom-6 right-6 rounded-md bg-slate-900 px-4 py-2 text-sm text-slate-200 shadow-lg";
+        document.body.appendChild(toast);
+        setTimeout(() => toast.remove(), 1200);
+      }
+    };
+    document.addEventListener("keydown", handleSave);
+    return () => document.removeEventListener("keydown", handleSave);
+  }, []);
+}

--- a/src/features/sidebar/Sidebar.tsx
+++ b/src/features/sidebar/Sidebar.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import {
+  Bars3Icon,
+  ChatBubbleLeftRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PlusIcon,
+  TrashIcon
+} from "@heroicons/react/24/outline";
+import { useActions, useAppState } from "../../state/store";
+import { formatDistanceToNow } from "date-fns";
+
+export default function Sidebar() {
+  const state = useAppState();
+  const actions = useActions();
+  const [query, setQuery] = useState("");
+  const location = useLocation();
+  const navigate = useNavigate();
+  const collapsed = state.ui.sidebarCollapsed;
+
+  const chats = useMemo(() => {
+    const list = state.chatOrder
+      .map((id) => state.chats[id])
+      .filter(Boolean)
+      .filter((chat) =>
+        chat.meta.title.toLowerCase().includes(query.trim().toLowerCase())
+      );
+    return list;
+  }, [query, state.chatOrder, state.chats]);
+
+  return (
+    <aside
+      className={`flex h-full flex-col border-r border-slate-800 bg-slate-950/95 backdrop-blur transition-all duration-200 ${collapsed ? "w-14" : "w-72"}`}
+    >
+      <div className="flex items-center justify-between border-b border-slate-800 px-3 py-2">
+        <button
+          type="button"
+          className="flex items-center gap-2 text-sm text-slate-100"
+          onClick={() => actions.toggleSidebar()}
+        >
+          <Bars3Icon className="h-5 w-5" />
+          {!collapsed && <span>Chats</span>}
+        </button>
+        {!collapsed && (
+          <button
+            type="button"
+            className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:bg-slate-800"
+            onClick={() => {
+              const id = actions.createChat();
+              navigate(`/chat/${id}`);
+            }}
+          >
+            <PlusIcon className="mr-1 inline h-4 w-4" /> New Chat
+          </button>
+        )}
+      </div>
+      {!collapsed && (
+        <div className="px-3 py-2">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search chats"
+            className="w-full rounded-md border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-500 focus:border-slate-500 focus:outline-none"
+          />
+        </div>
+      )}
+      <nav className="flex-1 overflow-y-auto">
+        <ul className="space-y-1 px-2 py-2">
+          {chats.map((chat) => {
+            const active = location.pathname.includes(chat.meta.id);
+            return (
+              <li key={chat.meta.id}>
+                <Link
+                  to={`/chat/${chat.meta.id}`}
+                  className={`flex items-center justify-between rounded-md px-3 py-2 text-sm transition hover:bg-slate-800 ${
+                    active ? "bg-slate-800 text-slate-100" : "text-slate-300"
+                  }`}
+                >
+                  <div className="flex flex-1 flex-col">
+                    <span className="flex items-center gap-2">
+                      <ChatBubbleLeftRightIcon className="h-4 w-4" />
+                      <span className="truncate">{chat.meta.title || "Untitled chat"}</span>
+                    </span>
+                    <span className="mt-1 text-xs text-slate-400">
+                      Updated {formatDistanceToNow(new Date(chat.meta.updatedAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className="ml-2 rounded p-1 text-slate-500 hover:bg-slate-900 hover:text-red-400"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      actions.deleteChat(chat.meta.id);
+                    }}
+                    aria-label="Delete chat"
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <button
+        type="button"
+        className="flex items-center justify-center gap-1 border-t border-slate-800 py-2 text-xs text-slate-400 hover:text-slate-200"
+        onClick={() => actions.toggleSidebar()}
+      >
+        {collapsed ? (
+          <>
+            <ChevronRightIcon className="h-4 w-4" /> Expand
+          </>
+        ) : (
+          <>
+            <ChevronLeftIcon className="h-4 w-4" /> Collapse
+          </>
+        )}
+      </button>
+    </aside>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  @apply bg-canvas-dark text-slate-100;
+}
+
+.canvas-grid {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+.node-card-shadow {
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.45);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,19 @@
+import "./index.css";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,476 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { nanoid } from "nanoid";
+import produce from "immer";
+import type {
+  AppState,
+  Chat,
+  ChatNode,
+  SerializedState,
+  StoreActions,
+  StoreState,
+  ViewportState
+} from "./types";
+import { clamp } from "../utils/math";
+import { isDescendant } from "../utils/tree";
+
+const SCHEMA_VERSION = 1;
+const STORAGE_KEY = "branch.v1";
+
+const initialViewport: ViewportState = {
+  x: 0,
+  y: 0,
+  zoom: 0.9
+};
+
+const emptyState: AppState = {
+  chats: {},
+  chatOrder: [],
+  activeChatId: undefined,
+  selection: { nodeIds: [] },
+  ui: {
+    sidebarCollapsed: false,
+    gridSnap: true,
+    dragging: false,
+    editingNodeId: undefined
+  }
+};
+
+function createChatMeta(): Chat {
+  const id = nanoid();
+  const now = new Date().toISOString();
+  return {
+    meta: {
+      id,
+      title: "Untitled chat",
+      createdAt: now,
+      updatedAt: now,
+      viewport: { ...initialViewport },
+      theme: "dark",
+      version: SCHEMA_VERSION
+    },
+    nodes: {}
+  };
+}
+
+function pushHistory(state: StoreState, next: AppState): StoreState {
+  const maxHistory = 100;
+  const past = state.history.past.slice(-maxHistory + 1);
+  return {
+    ...state,
+    history: {
+      past: [...past, state.history.present],
+      present: next,
+      future: []
+    }
+  };
+}
+
+function applyUpdate(state: StoreState, recipe: (draft: AppState) => void): StoreState {
+  const next = produce(state.history.present, (draft) => {
+    recipe(draft);
+    draft.selection.edge = undefined;
+  });
+  return pushHistory(state, next);
+}
+
+function ensureChat(state: AppState, chatId: string): Chat {
+  const chat = state.chats[chatId];
+  if (!chat) {
+    throw new Error(`Chat ${chatId} not found`);
+  }
+  return chat;
+}
+
+function createNodeSkeleton(params: {
+  chatId: string;
+  parentId?: string;
+  role?: ChatNode["role"];
+  x: number;
+  y: number;
+}): ChatNode {
+  const id = nanoid();
+  const now = new Date().toISOString();
+  return {
+    id,
+    chatId: params.chatId,
+    role: params.role ?? (params.parentId ? "assistant" : "user"),
+    parentId: params.parentId,
+    children: [],
+    text: "",
+    createdAt: now,
+    updatedAt: now,
+    status: "draft",
+    x: params.x,
+    y: params.y,
+    width: 280,
+    height: 160
+  };
+}
+
+const useStore = create<StoreState>()(
+  persist(
+    (set, get) => {
+      const actions: StoreActions = {
+        setActiveChat: (chatId) => {
+          set((state) =>
+            produce(state, (draft) => {
+              if (!draft.history.present.chats[chatId]) return;
+              draft.history.present.activeChatId = chatId;
+            })
+          );
+        },
+        createChat: () => {
+          const chat = createChatMeta();
+          set((state) => {
+            const next = produce(state.history.present, (draft) => {
+              draft.chats[chat.meta.id] = chat;
+              draft.chatOrder.unshift(chat.meta.id);
+              draft.activeChatId = chat.meta.id;
+              draft.selection = { nodeIds: [] };
+            });
+            return pushHistory(state, next);
+          });
+          return chat.meta.id;
+        },
+        renameChat: (chatId, title) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = ensureChat(draft, chatId);
+              chat.meta.title = title || "Untitled chat";
+              chat.meta.updatedAt = new Date().toISOString();
+            })
+          );
+        },
+        deleteChat: (chatId) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              if (!draft.chats[chatId]) return;
+              delete draft.chats[chatId];
+              draft.chatOrder = draft.chatOrder.filter((id) => id !== chatId);
+              if (draft.activeChatId === chatId) {
+                draft.activeChatId = draft.chatOrder[0];
+              }
+              draft.selection = { nodeIds: [] };
+            })
+          );
+        },
+        createNode: ({ chatId, parentId, role, x, y, autoFocus = true }) => {
+          const node = createNodeSkeleton({ chatId, parentId, role, x, y });
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = ensureChat(draft, chatId);
+              chat.nodes[node.id] = node;
+              if (parentId) {
+                const parent = chat.nodes[parentId];
+                if (parent) {
+                  parent.children.push(node.id);
+                }
+              }
+              chat.meta.updatedAt = new Date().toISOString();
+              if (autoFocus) {
+                draft.selection = { nodeIds: [node.id] };
+                draft.ui.editingNodeId = node.id;
+              }
+            })
+          );
+          return node.id;
+        },
+        updateNodeText: (nodeId, text) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              for (const chat of Object.values(draft.chats)) {
+                const node = chat.nodes[nodeId];
+                if (node) {
+                  node.text = text;
+                  node.updatedAt = new Date().toISOString();
+                  chat.meta.updatedAt = node.updatedAt;
+                  if (!chat.meta.title || chat.meta.title === "Untitled chat") {
+                    chat.meta.title = text.slice(0, 60) || "Untitled chat";
+                  }
+                  break;
+                }
+              }
+            })
+          );
+        },
+        setNodeStatus: (nodeId, status) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              for (const chat of Object.values(draft.chats)) {
+                const node = chat.nodes[nodeId];
+                if (node) {
+                  node.status = status;
+                  node.updatedAt = new Date().toISOString();
+                  break;
+                }
+              }
+            })
+          );
+        },
+        moveNodes: (nodeIds, dx, dy) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const activeChat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!activeChat) return;
+              for (const id of nodeIds) {
+                const node = activeChat.nodes[id];
+                if (node) {
+                  node.x += dx;
+                  node.y += dy;
+                }
+              }
+            })
+          );
+        },
+        setNodePosition: (nodeId, x, y) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!chat) return;
+              const node = chat.nodes[nodeId];
+              if (!node) return;
+              node.x = x;
+              node.y = y;
+            })
+          );
+        },
+        resizeNode: (nodeId, width, height) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!chat) return;
+              const node = chat.nodes[nodeId];
+              if (!node) return;
+              node.width = clamp(width, 180, 1200);
+              node.height = clamp(height, 80, 1000);
+            })
+          );
+        },
+        reparentNode: (nodeId, parentId, index) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!chat) return;
+              const node = chat.nodes[nodeId];
+              if (!node) return;
+              if (parentId && isDescendant(chat.nodes, parentId, nodeId)) {
+                return;
+              }
+              const oldParent = node.parentId ? chat.nodes[node.parentId] : undefined;
+              if (oldParent) {
+                oldParent.children = oldParent.children.filter((id) => id !== node.id);
+              }
+              if (!parentId) {
+                node.parentId = undefined;
+              } else {
+                const newParent = chat.nodes[parentId];
+                if (!newParent) return;
+                node.parentId = parentId;
+                if (index === undefined || index >= newParent.children.length) {
+                  newParent.children.push(node.id);
+                } else {
+                  newParent.children.splice(index, 0, node.id);
+                }
+              }
+            })
+          );
+        },
+        deleteNode: (nodeId, mode) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!chat) return;
+              const node = chat.nodes[nodeId];
+              if (!node) return;
+              const removeSubtree = (id: string) => {
+                const current = chat.nodes[id];
+                if (!current) return;
+                for (const childId of current.children) {
+                  removeSubtree(childId);
+                }
+                delete chat.nodes[id];
+              };
+              const parent = node.parentId ? chat.nodes[node.parentId] : undefined;
+              if (mode === "subtree") {
+                removeSubtree(nodeId);
+              } else if (parent) {
+                const index = parent.children.indexOf(nodeId);
+                parent.children.splice(index, 1);
+                for (const childId of node.children) {
+                  const child = chat.nodes[childId];
+                  if (child) {
+                    child.parentId = parent.id;
+                    parent.children.splice(index, 0, childId);
+                  }
+                }
+                delete chat.nodes[nodeId];
+              } else {
+                removeSubtree(nodeId);
+              }
+              draft.selection = { nodeIds: [] };
+            })
+          );
+        },
+        deleteEdge: (parentId, childId) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.activeChatId && draft.chats[draft.activeChatId];
+              if (!chat) return;
+              const parent = chat.nodes[parentId];
+              const child = chat.nodes[childId];
+              if (!parent || !child) return;
+              parent.children = parent.children.filter((id) => id !== childId);
+              child.parentId = undefined;
+              draft.selection = { nodeIds: [childId] };
+            })
+          );
+        },
+        selectNodes: (nodeIds) => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.selection = { nodeIds };
+            })
+          );
+        },
+        selectEdge: (parentId, childId) => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.selection = {
+                nodeIds: [],
+                edge: { parentId, childId }
+              };
+            })
+          );
+        },
+        clearSelection: () => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.selection = { nodeIds: [] };
+            })
+          );
+        },
+        setViewport: (chatId, viewport) => {
+          set((state) =>
+            applyUpdate(state, (draft) => {
+              const chat = draft.chats[chatId];
+              if (!chat) return;
+              chat.meta.viewport = {
+                x: viewport.x,
+                y: viewport.y,
+                zoom: clamp(viewport.zoom, 0.25, 2)
+              };
+            })
+          );
+        },
+        toggleSidebar: () => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.ui.sidebarCollapsed = !draft.history.present.ui.sidebarCollapsed;
+            })
+          );
+        },
+        toggleGridSnap: () => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.ui.gridSnap = !draft.history.present.ui.gridSnap;
+            })
+          );
+        },
+        setEditingNode: (nodeId) => {
+          set((state) =>
+            produce(state, (draft) => {
+              draft.history.present.ui.editingNodeId = nodeId;
+            })
+          );
+        },
+        undo: () => {
+          set((state) => {
+            if (!state.history.past.length) return state;
+            const previous = state.history.past[state.history.past.length - 1];
+            const past = state.history.past.slice(0, -1);
+            const future = [state.history.present, ...state.history.future];
+            return {
+              ...state,
+              history: { past, present: previous, future }
+            };
+          });
+        },
+        redo: () => {
+          set((state) => {
+            if (!state.history.future.length) return state;
+            const [next, ...rest] = state.history.future;
+            return {
+              ...state,
+              history: {
+                past: [...state.history.past, state.history.present],
+                present: next,
+                future: rest
+              }
+            };
+          });
+        },
+        importData: (appState) => {
+          set((state) => pushHistory(state, appState));
+        }
+      };
+
+      return {
+        history: {
+          past: [],
+          present: emptyState,
+          future: []
+        },
+        actions
+      };
+    },
+    {
+      name: STORAGE_KEY,
+      version: SCHEMA_VERSION,
+      partialize: (state) => {
+        const present = state.history.present;
+        const serialized: SerializedState = {
+          schemaVersion: SCHEMA_VERSION,
+          chats: present.chats,
+          chatOrder: present.chatOrder,
+          activeChatId: present.activeChatId
+        };
+        return {
+          history: {
+            past: [],
+            present,
+            future: []
+          },
+          actions: state.actions,
+          ...serialized
+        } as unknown as StoreState;
+      },
+      merge: (persistedState, currentState) => {
+        if (!persistedState) return currentState;
+        const parsed = persistedState as StoreState & SerializedState;
+        const present: AppState = {
+          chats: parsed.chats ?? {},
+          chatOrder: parsed.chatOrder ?? [],
+          activeChatId: parsed.activeChatId,
+          selection: { nodeIds: [] },
+          ui: {
+            sidebarCollapsed: false,
+            gridSnap: true,
+            dragging: false,
+            editingNodeId: undefined
+          }
+        };
+        return {
+          history: { past: [], present, future: [] },
+          actions: currentState.actions
+        };
+      }
+    }
+  )
+);
+
+export const useAppState = () => useStore((state) => state.history.present);
+export const useActions = () => useStore((state) => state.actions);
+export const useHistory = () => useStore((state) => state.history);
+
+export default useStore;

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,110 @@
+export type Role = "user" | "assistant" | "note";
+export type NodeStatus = "draft" | "sending" | "done" | "error";
+
+export interface ChatNode {
+  id: string;
+  chatId: string;
+  role: Role;
+  parentId?: string;
+  children: string[];
+  text: string;
+  createdAt: string;
+  updatedAt: string;
+  status: NodeStatus;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ViewportState {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export interface ChatTreeMeta {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  viewport: ViewportState;
+  theme: "dark" | "light" | "system";
+  version: number;
+}
+
+export interface Chat {
+  meta: ChatTreeMeta;
+  nodes: Record<string, ChatNode>;
+}
+
+export interface SelectionState {
+  nodeIds: string[];
+  edge?: { parentId: string; childId: string };
+}
+
+export interface UIState {
+  sidebarCollapsed: boolean;
+  gridSnap: boolean;
+  dragging: boolean;
+  editingNodeId?: string;
+}
+
+export interface HistoryState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+}
+
+export interface AppState {
+  chats: Record<string, Chat>;
+  chatOrder: string[];
+  activeChatId?: string;
+  selection: SelectionState;
+  ui: UIState;
+}
+
+export interface StoreState {
+  history: HistoryState<AppState>;
+  actions: StoreActions;
+}
+
+export interface StoreActions {
+  setActiveChat: (chatId: string) => void;
+  createChat: () => string;
+  renameChat: (chatId: string, title: string) => void;
+  deleteChat: (chatId: string) => void;
+  createNode: (options: {
+    chatId: string;
+    parentId?: string;
+    role?: Role;
+    x: number;
+    y: number;
+    autoFocus?: boolean;
+  }) => string;
+  updateNodeText: (nodeId: string, text: string) => void;
+  setNodeStatus: (nodeId: string, status: NodeStatus) => void;
+  moveNodes: (nodeIds: string[], dx: number, dy: number) => void;
+  setNodePosition: (nodeId: string, x: number, y: number) => void;
+  resizeNode: (nodeId: string, width: number, height: number) => void;
+  reparentNode: (nodeId: string, parentId?: string, index?: number) => void;
+  deleteNode: (nodeId: string, mode: "subtree" | "promoteChildren") => void;
+  deleteEdge: (parentId: string, childId: string) => void;
+  selectNodes: (nodeIds: string[]) => void;
+  selectEdge: (parentId: string, childId: string) => void;
+  clearSelection: () => void;
+  setViewport: (chatId: string, viewport: ViewportState) => void;
+  toggleSidebar: () => void;
+  toggleGridSnap: () => void;
+  setEditingNode: (nodeId?: string) => void;
+  undo: () => void;
+  redo: () => void;
+  importData: (state: AppState) => void;
+}
+
+export interface SerializedState {
+  schemaVersion: number;
+  chats: Record<string, Chat>;
+  chatOrder: string[];
+  activeChatId?: string;
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,21 @@
+import type { Chat, ChatNode } from "../state/types";
+
+export interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export function pathMessages(chat: Chat, upToNodeId: string): Message[] {
+  const nodes = chat.nodes;
+  const path: ChatNode[] = [];
+  let current = nodes[upToNodeId];
+  while (current) {
+    path.push(current);
+    if (!current.parentId) break;
+    current = nodes[current.parentId];
+  }
+  return path
+    .reverse()
+    .filter((node) => node.role === "user" || node.role === "assistant")
+    .map((node) => ({ role: node.role as Message["role"], content: node.text }));
+}

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,7 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function snap(value: number, gridSize: number): number {
+  return Math.round(value / gridSize) * gridSize;
+}

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -1,0 +1,51 @@
+import type { AppState } from "../state/types";
+
+const DOWNLOAD_NAME = "branch-export.branch.json";
+const SCHEMA_VERSION = 1;
+
+export function exportChats(state: AppState) {
+  const payload = {
+    schemaVersion: SCHEMA_VERSION,
+    chats: state.chats,
+    chatOrder: state.chatOrder,
+    activeChatId: state.activeChatId
+  } satisfies AppState & { schemaVersion: number };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json"
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = DOWNLOAD_NAME;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export async function importChats(callback: (state: AppState) => void) {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json,.branch.json";
+  input.onchange = async () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const json = JSON.parse(text);
+    if (json.schemaVersion !== SCHEMA_VERSION) {
+      console.warn("Unsupported schema version", json.schemaVersion);
+    }
+    callback({
+      chats: json.chats ?? {},
+      chatOrder: json.chatOrder ?? [],
+      activeChatId: json.activeChatId,
+      selection: { nodeIds: [] },
+      ui: {
+        sidebarCollapsed: false,
+        gridSnap: true,
+        dragging: false,
+        editingNodeId: undefined
+      }
+    });
+  };
+  input.click();
+}

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -1,0 +1,32 @@
+import type { ChatNode } from "../state/types";
+
+export function isDescendant(nodes: Record<string, ChatNode>, ancestorId: string, nodeId: string): boolean {
+  const visited = new Set<string>();
+  const stack: string[] = [ancestorId];
+  while (stack.length) {
+    const currentId = stack.pop();
+    if (!currentId || visited.has(currentId)) continue;
+    visited.add(currentId);
+    if (currentId === nodeId) return true;
+    const node = nodes[currentId];
+    if (node) {
+      stack.push(...node.children);
+    }
+  }
+  return false;
+}
+
+export function getAncestors(nodes: Record<string, ChatNode>, nodeId: string): ChatNode[] {
+  const path: ChatNode[] = [];
+  let current = nodes[nodeId];
+  while (current) {
+    path.push(current);
+    if (!current.parentId) break;
+    current = nodes[current.parentId];
+  }
+  return path;
+}
+
+export function getRoots(nodes: Record<string, ChatNode>): ChatNode[] {
+  return Object.values(nodes).filter((node) => !node.parentId);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{ts,tsx}"] ,
+  theme: {
+    extend: {
+      colors: {
+        canvas: {
+          light: "#f9fafb",
+          dark: "#111827"
+        }
+      },
+      boxShadow: {
+        card: "0 12px 32px rgba(15, 23, 42, 0.25)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest", "vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: "0.0.0.0"
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React 18 + TypeScript workspace with TailwindCSS, Zustand persistence, and project tooling
- implement the Branch canvas experience with pan/zoom, draggable/resizable node cards, linking, active-path highlighting, and mock Ask AI flows
- add sidebar, top bar, keyboard shortcuts, import/export helpers, and undo/redo-capable state management aligned with the Tree-Chat spec

## Testing
- npm install *(fails: registry returned HTTP 403 for @headlessui/react)*

------
https://chatgpt.com/codex/tasks/task_e_68e57f7c0f2c832399ec517f3660aa1a